### PR TITLE
[node] Set Upgrade and Connection headers to allow web-sockets

### DIFF
--- a/node/8/nginx.conf
+++ b/node/8/nginx.conf
@@ -54,5 +54,10 @@ server {
         proxy_pass http://127.0.0.1:3000;
         proxy_set_header Host $http_host;
         proxy_redirect off;
+        
+        # To support WebSockets
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
     }
 }


### PR DESCRIPTION
Although I'm not sure if it's right to set these for all requests.

Might be a better idea to have a separate route like (as [described here](https://www.nginx.com/blog/websocket-nginx/)):
```conf
location /wsapp/ {
    proxy_pass http://wsbackend;
    proxy_http_version 1.1;
    proxy_set_header Upgrade $http_upgrade;
    proxy_set_header Connection "Upgrade";
}
```